### PR TITLE
Fix 'unreachable code' panic in Persistent Subscriptions

### DIFF
--- a/eventstore/src/commands.rs
+++ b/eventstore/src/commands.rs
@@ -1378,13 +1378,12 @@ impl PersistentSubscription {
 
                 Err(e)
             }
-            Ok(resp) => {
-                if let Some(content) = resp.and_then(|r| r.content) {
-                    return Ok(content.into());
-                }
-
-                unreachable!()
-            }
+            Ok(Some(crate::event_store::client::persistent::ReadResp {
+                content: Some(content),
+            })) => Ok(content.into()),
+            Ok(_) => Err(crate::Error::IllegalStateError(
+                "Persistent subscription returned no response".to_string(),
+            )),
         }
     }
 


### PR DESCRIPTION
I encountered this `unreachable!()` panic quite a lot when using Persistent Subscriptions. I'm not entirely sure the cause, but as I am hitting it then it's fair to say it's not "unreachable". By changing this to an `Err` it resolves my panic issue.