### PR TITLE
docs: correct article usage with "Kurrent"

### DIFF
--- a/kurrentdb/src/client.rs
+++ b/kurrentdb/src/client.rs
@@ -23,7 +23,7 @@ use crate::{
 /// Represents a client to a single node. `Client` maintains a full duplex
 /// communication to KurrentDB.
 ///
-/// Many threads can use an KurrentDB client at the same time
+/// Many threads can use a KurrentDB client at the same time
 /// or a single thread can make many asynchronous requests.
 #[derive(Clone)]
 pub struct Client {
@@ -32,12 +32,12 @@ pub struct Client {
 }
 
 impl Client {
-    /// Creates a gRPC client to an KurrentDB database.
+    /// Creates a gRPC client to a KurrentDB database.
     pub fn new(settings: ClientSettings) -> crate::Result<Self> {
         Client::with_runtime_handle(tokio::runtime::Handle::current(), settings)
     }
 
-    /// Creates a gRPC client to an KurrentDB database using an existing tokio runtime.
+    /// Creates a gRPC client to a KurrentDB database using an existing tokio runtime.
     pub fn with_runtime_handle(
         handle: tokio::runtime::Handle,
         settings: ClientSettings,

--- a/kurrentdb/src/grpc.rs
+++ b/kurrentdb/src/grpc.rs
@@ -258,7 +258,7 @@ fn default_keep_alive_timeout() -> Duration {
     ClientSettings::default().keep_alive_timeout
 }
 
-/// Gathers all the settings related to a gRPC client with an KurrentDB database.
+/// Gathers all the settings related to a gRPC client with a KurrentDB database.
 /// `ClientSettings` can only be created when parsing a connection string.
 ///
 /// ```


### PR DESCRIPTION
This PR addresses grammatical issues that occurred during the rebranding from "Event Store" to "Kurrent". The main issue was incorrect article usage - using "an KurrentDB" instead of "a KurrentDB" since "Kurrent" starts with a consonant sound.