### PR TITLE
Don't panic if rustls is already initialized

### DIFF
--- a/kurrentdb/src/grpc.rs
+++ b/kurrentdb/src/grpc.rs
@@ -854,7 +854,7 @@ impl NodeConnection {
         RUSTLS_INIT.call_once(|| {
             rustls::crypto::aws_lc_rs::default_provider()
                 .install_default()
-                .expect("failed to install rustls crypto provider");
+                .ok();
         });
 
         if let Some(cert) = settings.tls_ca_file() {


### PR DESCRIPTION
Hello!

We initialize `rustls` before we initialize `kurrentdb`, and we are unable to upgrade to v4 because `kurrentdb` panics because `rustls` is already initialized. 